### PR TITLE
Fix check_license fail when XILINXD_LICENSE_FILE points to a floating license server.

### DIFF
--- a/npu/build/build_template/check_license.sh
+++ b/npu/build/build_template/check_license.sh
@@ -9,10 +9,18 @@ if [ -z "$XILINXD_LICENSE_FILE" ]; then
     echo "Please see https://riallto.ai/install-riallto.html for license setup instructions."
     exit 1
 else
-    # If variable set, see if file exists
-    if [ ! -e "$XILINXD_LICENSE_FILE" ]; then
-        echo "The license file $XILINXD_LICENSE_FILE does not exist."
-        echo "Please see https://riallto.ai/install-riallto.html for license setup instructions."
-        exit 1
+    # Check if XILINXD_LICENSE_FILE is a file
+    if [ -e "$XILINXD_LICENSE_FILE" ]; then
+        echo "Found license file: $XILINXD_LICENSE_FILE"
+    else
+        # Assume XILINXD_LICENSE_FILE is a server, try to ping
+        server_address=$(echo $XILINXD_LICENSE_FILE | cut -d@ -f2)
+        if ping -c 1 $server_address &> /dev/null; then
+            echo "Server $server_address is reachable."
+        else
+            echo "Could not find license file of reach server address $server_address."
+            echo "Please see https://riallto.ai/install-riallto.html for license setup instructions."
+            exit 1
+        fi
     fi
 fi


### PR DESCRIPTION
Adds an additional check to see if the license file is on a floating license server.

<!-- Thanks for taking the time to submit a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->

### Describe the problem solved by the commit
When checking the license file if the license file is set as a floating license server then the check_license script will stop the build progressing.

### How is the problem solved?
If it cannot find a file associated with the license it tries to ping it as a server. If it cannot get a ping to the server it then returns an error.

### Are there any risks associated to the change?
Yes, this can effect the build flow.

### Is there a documentation impact?
No. 

### Checklist

<!-- We suggest you run all the pytests and report the output. Put an `x` in the boxes that apply -->

- [X] I added a test to cover my changes
- [X] Existing and new test pass
- [X] I read and I accept the [CONTRIBUTING.md](https://github.com/AMDResearch/Riallto/blob/main/CONTRIBUTING.md) guidelines

### Please provide screenshots (if applicable)

### Related issues
