### PR TITLE
extra symbols to wsl path resolution

### DIFF
--- a/scripts/wsl/copy_files_to_wsl.ps1
+++ b/scripts/wsl/copy_files_to_wsl.ps1
@@ -6,7 +6,11 @@ param(
   [string]$repoPath = "Riallto"
 )
 
+# Replace slashes and spaces
 $repoPathWSL = "/mnt/" + ($repoPath -replace ":", "").Replace("\", "/").Replace(" ", "\ ").ToLower()
+
+# Replace special characters
+$repoPathWSL = $repoPathWSL -replace '\(', '\(' -replace '\)', '\)'
 
 $wslName = "Riallto"
 


### PR DESCRIPTION
### Describe the problem solved by the commit
This fixes bug found by @cathalmccabe. If install is run from e.g. "C:/users/john/downloads/my folder (1)/" it will currently fail because we don't escape the special ')' characters when converting to wsl strings.

Btw it looks like '\(' is being replaced by same '\(', but this actually does what we want because the first argument of -replace is a regular expression, the second one is the string that will be inserted, so functionally '(' -> '\('.

### How is the problem solved?
Add a one-liner to the copy_files_to_wsl.ps1 script.


### Checklist

<!-- We suggest you run all the pytests and report the output. Put an `x` in the boxes that apply -->

- [x] I read and I accept the [CONTRIBUTING.md](https://github.com/AMDResearch/Riallto/blob/main/CONTRIBUTING.md) guidelines

 Signed-off-by: skalade <sarunas.kalade@amd.com>