### PR TITLE
Latest version of numpy causing issues, constraining it to v1.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     packages=find_packages(),
     python_requires="==3.9.*",
     install_requires=[
-        "numpy==1.*",
+        "numpy<2.0",
         "pytest",
         "pytest-cov",
         "opencv-python",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     packages=find_packages(),
     python_requires="==3.9.*",
     install_requires=[
-        "numpy",
+        "numpy==1.*",
         "pytest",
         "pytest-cov",
         "opencv-python",


### PR DESCRIPTION
<!-- Thanks for taking the time to submit a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->

### Describe the problem solved by the commit

Numpy 2.0 is causing some issues and the current setup.py does not constrain the version.

### How is the problem solved?

Constrain setup.py to use numpy==1.*

### Are there any risks associated to the change?

None

### Is there a documentation impact?

None

### Checklist

<!-- We suggest you run all the pytests and report the output. Put an `x` in the boxes that apply -->

- [- ] I added a test to cover my changes
- [x ] Existing and new test pass
- [x ] I read and I accept the [CONTRIBUTING.md](https://github.com/AMDResearch/Riallto/blob/main/CONTRIBUTING.md) guidelines

### Please provide screenshots (if applicable)

### Related issues
