### PR TITLE
Add CNAME to point to riallto.ai

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+riallto.ai


### PR DESCRIPTION
riallto.ai is broken. Add riallto domain to fix it.  