### PR TITLE
bugfix single kernel, two outputs to system memory error

### DIFF
--- a/npu/build/kernel.py
+++ b/npu/build/kernel.py
@@ -230,7 +230,7 @@ class Kernel(KernelMeta):
         if len(outputs) == 1:
             return outputs[0]
         else:
-            return outputs
+            return tuple(outputs)
 
     def build(self, debug=False):
         """Build the kernel object file for linking into the complete application."""

--- a/tests/test_singlekernel.py
+++ b/tests/test_singlekernel.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import pytest
+import numpy as np
+from npu.utils.test_device import get_device_status
+from .test_applications import check_npu, manage_testing
+
+import pytest
+from npu.build.kernel import Kernel
+from npu.build.appbuilder import AppBuilder
+from npu.runtime import AppRunner
+
+def vbc_behavioral(obj):
+    obj.c.array = obj.a.array
+    obj.b.array = obj.a.array
+
+class VectorBroadcastApp(AppBuilder):
+    def __init__(self) -> None:
+
+        self.vectorbroadcast = Kernel('''
+        #include <stdint.h>
+        #include <stdio.h>
+        #include <stdlib.h>
+        #include <aie_api/aie.hpp>
+
+        extern "C" {
+        void vectorbroadcast(uint8_t* a, uint8_t* b, uint8_t* c, const uint32_t nbytes) {
+
+            ::aie::vector<uint8_t, 32> ai, bi, ci;
+
+            for(int j=0; j<nbytes; j+=32) {
+                ai = ::aie::load_v<32>(a);
+                a += 32;
+                ::aie::store_v(b, ai);
+                b += 32;
+                ::aie::store_v(c, ai);
+                c += 32;
+            }
+        }
+        }
+        ''',vbc_behavioral)
+
+        super().__init__()
+    
+
+
+    """Callgraph to test two output kernel"""
+    def callgraph(self, x):
+        return self.vectorbroadcast(x, x.nbytes)
+
+
+
+
+def test_singlekernel_twooutput_build(manage_testing):
+    """ Test the simplest single kernel app with two outputs."""
+
+    appb = VectorBroadcastApp()
+
+    a = np.random.randint(0, 256, size=4096, dtype=np.uint8)
+
+    appb.build(a)
+
+    appr = AppRunner("VectorBroadcastApp.xclbin")
+
+
+    a_in = appr.allocate(shape=a.shape, dtype=a.dtype)
+    b_out = appr.allocate(shape=a.shape, dtype=a.dtype)
+    c_out = appr.allocate(shape=a.shape, dtype=a.dtype)    
+
+    a_in[:] = a
+    a_in.sync_to_npu()
+
+    appr._refresh_sequence()
+    appr.call(a_in, b_out, c_out)
+
+    b_out.sync_from_npu()
+    c_out.sync_from_npu()   
+    print(np.array(a_in),np.array(b_out),np.array(c_out))
+
+    assert np.array_equal(a_in, b_out)
+    assert np.array_equal(a_in, c_out)
+
+    del appr


### PR DESCRIPTION
<!-- Thanks for taking the time to submit a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->

### Describe the problem solved by the commit

Kernels producing multiple outputs that are routed to system memory was not handled correctly

### How is the problem solved?

Unified kernel outputs to be tuples like other data structures.  All pytests are passing 

### Are there any risks associated to the change?

No

### Is there a documentation impact?

No

### Checklist

<!-- We suggest you run all the pytests and report the output. Put an `x` in the boxes that apply -->

- [x] I added a test to cover my changes
- [x] Existing and new test pass
- [x] I read and I accept the [CONTRIBUTING.md](https://github.com/AMDResearch/Riallto/blob/main/CONTRIBUTING.md) guidelines

### Please provide screenshots (if applicable)

### Related issues
