### PR TITLE
Videoapp image fix for image files

### DIFF
--- a/npu/lib/applications/videoapps.py
+++ b/npu/lib/applications/videoapps.py
@@ -82,9 +82,10 @@ def _set_webcam_resolution(cap, height: int, width: int) -> bool:
     """
     _ = cap.set(cv2.CAP_PROP_FRAME_WIDTH, width)
     _ = cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
-    if width != int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)):
-        return False
-    return True
+    if width == int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)) and \
+        height == int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)):
+        return True
+    return False
 
 
 def _set_supported_webcam_resolution(cap) -> bool:

--- a/tests/test_videoapps.py
+++ b/tests/test_videoapps.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import pytest
+from npu.utils import videoapps
+from npu.lib import (
+    ColorDetectVideoProcessing, ColorThresholdVideoProcessing,
+    DenoiseDPVideoProcessing, DenoiseTPVideoProcessing,
+    EdgeDetectVideoProcessing, ScaledColorThresholdVideoProcessing
+)
+
+
+files = ['../notebooks/images/jpg/toucan.jpg',
+         '../notebooks/images/png/ryzen-ai-sdk.png',
+         '../notebooks/images/gif/ping_pong_buffer.gif']
+
+testcases = [(vapp, file) for file in files for vapp in videoapps()]
+
+
+@pytest.mark.parametrize('testcase', testcases)
+def test_videoapp_use_jpg(testcase):
+    app, filename = testcase
+    appobj = eval(app)(filename)
+    assert appobj
+    del appobj

--- a/tests/test_videoapps.py
+++ b/tests/test_videoapps.py
@@ -22,6 +22,7 @@ testcases = [f'{vapp};{file}' for file in files for vapp in apps]
 
 @pytest.mark.parametrize('testcase', testcases)
 def test_videoapp_use_jpg(testcase):
+    """Test loading videoapp for a number of images"""
     app, filename = testcase.replace(' ', '').split(';')
     filename = os.path.dirname(os.path.abspath(__file__)) +'/'+ filename
     appobj = eval(app)(filename)

--- a/tests/test_videoapps.py
+++ b/tests/test_videoapps.py
@@ -17,12 +17,12 @@ files = ['../notebooks/images/jpg/toucan.jpg',
          '../notebooks/images/png/ryzen-ai-sdk.png',
          '../notebooks/images/gif/ping_pong_buffer.gif']
 
-testcases = [f'{vapp}; {file}' for file in files for vapp in apps]
+testcases = [f'{vapp};{file}' for file in files for vapp in apps]
 
 
 @pytest.mark.parametrize('testcase', testcases)
 def test_videoapp_use_jpg(testcase):
-    app, filename = testcase.split(';')
+    app, filename = testcase.replace(' ', '').split(';')
     filename = os.path.dirname(os.path.abspath(__file__)) +'/'+ filename
     appobj = eval(app)(filename)
     assert appobj

--- a/tests/test_videoapps.py
+++ b/tests/test_videoapps.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import pytest
+import os
 from npu.utils import videoapps
 from npu.lib import (
     ColorDetectVideoProcessing, ColorThresholdVideoProcessing,
@@ -20,6 +21,7 @@ testcases = [(vapp, file) for file in files for vapp in videoapps()]
 @pytest.mark.parametrize('testcase', testcases)
 def test_videoapp_use_jpg(testcase):
     app, filename = testcase
+    filename = os.path.dirname(os.path.abspath(__file__)) + filename
     appobj = eval(app)(filename)
     assert appobj
     del appobj

--- a/tests/test_videoapps.py
+++ b/tests/test_videoapps.py
@@ -21,7 +21,7 @@ testcases = [(vapp, file) for file in files for vapp in videoapps()]
 @pytest.mark.parametrize('testcase', testcases)
 def test_videoapp_use_jpg(testcase):
     app, filename = testcase
-    filename = os.path.dirname(os.path.abspath(__file__)) + filename
+    filename = os.path.dirname(os.path.abspath(__file__)) +'/'+ filename
     appobj = eval(app)(filename)
     assert appobj
     del appobj

--- a/tests/test_videoapps.py
+++ b/tests/test_videoapps.py
@@ -3,24 +3,26 @@
 
 import pytest
 import os
-from npu.utils import videoapps
 from npu.lib import (
     ColorDetectVideoProcessing, ColorThresholdVideoProcessing,
-    DenoiseDPVideoProcessing, DenoiseTPVideoProcessing,
-    EdgeDetectVideoProcessing, ScaledColorThresholdVideoProcessing
+    EdgeDetectVideoProcessing, ScaledColorThresholdVideoProcessing,
+    DenoiseDPVideoProcessing, DenoiseTPVideoProcessing
 )
 
+apps = ['ColorDetectVideoProcessing', 'ColorThresholdVideoProcessing',
+        'EdgeDetectVideoProcessing', 'ScaledColorThresholdVideoProcessing',
+        'DenoiseDPVideoProcessing', 'DenoiseTPVideoProcessing']
 
 files = ['../notebooks/images/jpg/toucan.jpg',
          '../notebooks/images/png/ryzen-ai-sdk.png',
          '../notebooks/images/gif/ping_pong_buffer.gif']
 
-testcases = [(vapp, file) for file in files for vapp in videoapps()]
+testcases = [f'{vapp}; {file}' for file in files for vapp in apps]
 
 
 @pytest.mark.parametrize('testcase', testcases)
 def test_videoapp_use_jpg(testcase):
-    app, filename = testcase
+    app, filename = testcase.split(';')
     filename = os.path.dirname(os.path.abspath(__file__)) +'/'+ filename
     appobj = eval(app)(filename)
     assert appobj


### PR DESCRIPTION
<!-- Thanks for taking the time to submit a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->

### Describe the problem solved by the commit

Code was not computing correctly the output image resolution, hence it was trying to download an non existing xclbin

### How is the problem solved?

Check input image height and width dimension to detect if resize is needed

### Are there any risks associated to the change?

No

### Is there a documentation impact?

No

### Checklist

<!-- We suggest you run all the pytests and report the output. Put an `x` in the boxes that apply -->

- [x] I added a test to cover my changes
- [x] Existing and new test pass
- [x] I read and I accept the [CONTRIBUTING.md](https://github.com/AMDResearch/Riallto/blob/main/CONTRIBUTING.md) guidelines

### Please provide screenshots (if applicable)

### Related issues
