### PR TITLE
Improve logic for `MTSplit`

### DIFF
--- a/npu/build/mlirbuilder.py
+++ b/npu/build/mlirbuilder.py
@@ -4,11 +4,9 @@
 from .mlirtiles import CTTile, MEMTile, ITTile
 from .buffers import MTBuffer
 from .mlirconnections import MLIRConnect, ObjectFIFO
-from .mlirsequencebuilder import MLIRSequnceBuilder 
+from .mlirsequencebuilder import MLIRSequnceBuilder
 from typing import Dict, List, Tuple
 from collections import OrderedDict
-from itertools import groupby
-import ctypes
 
 
 class MLIRBuilder:
@@ -17,7 +15,7 @@ class MLIRBuilder:
     Attributes
     ----------
     metadata : AppMetadata
-        The application metadata.  
+        The application metadata.
     app : JSON
         The json representation of an application metadata.
     kernels : dict
@@ -31,7 +29,7 @@ class MLIRBuilder:
     """
 
     def __init__(self, metadata, config=(4,1,1)):
-        """Return a new MLIRBuilder object.""" 
+        """Return a new MLIRBuilder object."""
         app = metadata.to_json()
         self.kernels = app['kernels']
         self.connections = app['connections']
@@ -43,7 +41,7 @@ class MLIRBuilder:
         MLIRConnect.reset_id()
 
         self.aietiles, self.memtiles, self.sdmatiles = self._parse_tiles(config)
-        self.tiles = {**self.sdmatiles,  **self.memtiles, **self.aietiles} 
+        self.tiles = {**self.sdmatiles,  **self.memtiles, **self.aietiles}
         self._map_kernels_to_tiles()
 
         self._cons_src2dst = self._populate_src2dst_cons_dict()
@@ -63,12 +61,11 @@ class MLIRBuilder:
         sdmas = {(ix, 0) : ITTile(ix, 0) for ix in range(config[1])}
         return aies, mts, sdmas
 
-
     def to_mlir(self, file=None):
         """Toplevel method to generate the application MLIR."""
         indent = "   "
         used_tiles = [tile for _, tile in self.tiles.items() if tile.is_used()]
-        used_aie_tiles = [tile for _, tile in self.aietiles.items() if tile.is_used()]        
+        used_aie_tiles = [tile for _, tile in self.aietiles.items() if tile.is_used()]
 
         s = 'module  {\n'
         s += f'{indent}AIE.device(ipu)'
@@ -91,7 +88,7 @@ class MLIRBuilder:
 
         for _, aie in self.aietiles.items():
             s += aie.to_mlir()
-            
+
         s += f'{self.seqbuilder.mlir}'
         s += ' }\n'
         s += "}\n"
@@ -102,8 +99,7 @@ class MLIRBuilder:
         with open(file, "w") as f:
             f.write(s)
 
-        return ""        
-
+        return ""
 
     def _map_kernels_to_tiles(self):
 
@@ -113,7 +109,7 @@ class MLIRBuilder:
 
                 if self.aietiles[k['tloc']].kernel is not None:
                     raise ValueError(f'Cannot place {k["name"]} kernel - CT tile previously constrained with {self.aietiles[k["tloc"]].kernel["name"]}')
-                self.aietiles[k['tloc']].kernel = k  
+                self.aietiles[k['tloc']].kernel = k
 
         # Then AIE kernels onto any free AIE Tiles
         # ...place all buffers on first MT / SDMA tiles
@@ -127,7 +123,7 @@ class MLIRBuilder:
                 for _, mt in self.memtiles.items():
                     k['tloc'] = mt.tloc
                     mt.buffers[kname] = k
-                    break 
+                    break
             elif k['type'] == 'IT':
                 for _, sdma in self.sdmatiles.items():
                     k['tloc'] = sdma.tloc
@@ -148,7 +144,7 @@ class MLIRBuilder:
             else:
                 cons_dict[con_src] = [con_dst]
         return cons_dict
-    
+
     def _populate_dst2src_cons_dict(self) -> Dict[Tuple[str,str], List[Tuple[str,str]]]:
         """ Creates a mapping dict of the connections where the key is the dst (kernel, port) tuple and
         the value is a list of source (kernel,port) tuples."""
@@ -160,8 +156,8 @@ class MLIRBuilder:
                 cons_dict[con_dst].append(con_src)
             else:
                 cons_dict[con_dst] = [con_src]
-        return cons_dict  
-    
+        return cons_dict
+
     def _populate_broadcast_dict(self) -> Dict[Tuple[str,str], List[Tuple[str,str]]]:
         """ Filters the dict of src2dst connection mappings produced by _populate_src2dst_cons_dict
         to produce a dict that only contains the broadcast pattern where the same data is going
@@ -176,7 +172,7 @@ class MLIRBuilder:
                         broadcasts[src] = dsts
                     elif bc_analysis == "MIX":
                         raise RuntimeError(f"""
-                         Mixing broadcasts and distributes from the same source is not yet supported 
+                         Mixing broadcasts and distributes from the same source is not yet supported
                          {src=} to {dsts=}
                          """)
         return broadcasts
@@ -188,8 +184,7 @@ class MLIRBuilder:
                 return False
         return True
 
-
-    def _all_unique(self, outgoing_shapes)->bool: 
+    def _all_unique(self, outgoing_shapes)->bool:
         seen_list = []
         for lst in outgoing_shapes.values():
             if lst in seen_list:
@@ -197,27 +192,26 @@ class MLIRBuilder:
         return True
 
     def _analyse_broadcast(self, src:Tuple[str,str]) -> str:
-        """When given a source (kernel, port) tuple determines if it is a: 
+        """When given a source (kernel, port) tuple determines if it is a:
         true broadcast, i.e. same data unique destinations (returns "BCAST");
         distribute op, i.e. different chunks of the data to different destinations (returns "DIST");
         a mix of both (returns "MIX").
         """
-        outgoing_shapes = {} 
+        outgoing_shapes = {}
         for s in self.sequence:
             con_src = (s['srckernelname'], s['srcportname'])
             if con_src  == src:
                 dst = (s['snkkernelname'], s['snkportname'])
                 outgoing_shape = (s['srcslices'], s['srcoffset'], s['srcnbytes'])
                 if dst not in outgoing_shapes:
-                    outgoing_shapes[dst] = [] 
+                    outgoing_shapes[dst] = []
                 outgoing_shapes[dst].append(outgoing_shape)
         if self._all_equal(outgoing_shapes):
             return "BCAST"
-        elif self._all_unique(outgoing_shapes): 
+        elif self._all_unique(outgoing_shapes):
             return "DIST"
         else:
             return "MIX"
-                
 
     def _get_bcast_nbytes_offset(self, bcast_src:Tuple[str,str])->Tuple[int,int]:
         for s in self.sequence:
@@ -229,11 +223,11 @@ class MLIRBuilder:
     def _map_connections_to_objectfifos(self):
         obfs = list()
         for s in [s for s in self.sequence if s['seqtype'] == 'buffer']:
-            for c in [c for c in self.connections if s['name'] == c]:                
+            for c in [c for c in self.connections if s['name'] == c]:
                 if c in [obf.name for obf in obfs]:
                     # TODO : validate that channel transfer nbytes is consistent
                     break
-                self.connections[c]['ctype'] = "objfifo,pingpong"                                      
+                self.connections[c]['ctype'] = "objfifo,pingpong"
 
                 src = (self.connections[c]['srckernel'],
                        self.connections[c]['srcport'])
@@ -243,11 +237,11 @@ class MLIRBuilder:
                              self.connections[c]['sinkport'])]
 
                     obfs.append(ObjectFIFO(c, src, dsts, s['nbytes'], s['offset'], self.tiles, self.kernels))
-        
+
         # map broadcast connections
         for src, dsts in self._cons_broadcasts.items():
             nbytes, offset = self._get_bcast_nbytes_offset(src)
-            obfs.append(ObjectFIFO(f"{src[0]}__{src[1]}", src, dsts, nbytes, offset, self.tiles, self.kernels)) 
+            obfs.append(ObjectFIFO(f"{src[0]}__{src[1]}", src, dsts, nbytes, offset, self.tiles, self.kernels))
 
         return obfs
 
@@ -277,7 +271,7 @@ class MLIRBuilder:
             elif isinstance(c.sinkkernel, MTBuffer):
                 if c.sinkkernel.name not in mt_buff_links:
                     mt_buff_links[c.sinkkernel.name] = { 'in' : [], 'out' : [] }
-                mt_buff_links[c.sinkkernel.name]['in'].append(c) 
+                mt_buff_links[c.sinkkernel.name]['in'].append(c)
                 mt_buff_links[c.sinkkernel.name]['in'] = self._sort_sinkport_mtbuff_links(mt_buff_links[c.sinkkernel.name]['in'])
         return mt_buff_links
 
@@ -294,7 +288,7 @@ class MLIRBuilder:
             raise ValueError(f'{type(connection.srcport.slices[0])} not '
                              'supported on MTBuffer source port')
         return sorted(buff_links, key=sorting_key)
-        
+
     def _sort_sinkport_mtbuff_links(self, buff_links)->List:
         def sorting_key(connection):
             if not connection.sinkport.slices:
@@ -314,7 +308,7 @@ class MLIRBuilder:
 
     def _get_objectfifo_varname(self, connection)->str:
         if self._is_con_broadcast(connection):
-            name = f"{connection.srckernel.name}__{connection.srcport.name}" 
+            name = f"{connection.srckernel.name}__{connection.srcport.name}"
         else:
             name = connection.name
 
@@ -337,7 +331,7 @@ class MLIRBuilder:
             if not self._is_mtlink_bcast(link):
                 s += self._generate_distribute_link(link, indent=indent)
             else:
-                s += self._generate_broadcast_link(link, mt_buff_links, indent=indent) 
+                s += self._generate_broadcast_link(link, mt_buff_links, indent=indent)
 
         return s
 
@@ -374,11 +368,10 @@ class MLIRBuilder:
                     return s
         raise RuntimeError(f"Unable to find a feeding buffer to link to in the memtile for {link=}")
 
-
     def _validate_app(self):
-        
+
         if len(self.kernels) == 0 or len(self.connections) == 0:
-            raise ValueError(f'{len(self.kernels)} kernels or {len(self.connections)} connections cannot be zero')            
+            raise ValueError(f'{len(self.kernels)} kernels or {len(self.connections)} connections cannot be zero')
 
         if len(self.aietiles) > len(self.aietiles):
             raise ValueError(f'{len(self.kernels)} kernels cannot be placed onto {len(self.aietiles)} AIE tiles')

--- a/npu/build/mlirbuilder.py
+++ b/npu/build/mlirbuilder.py
@@ -291,6 +291,8 @@ class MLIRBuilder:
                 return connection.srcport.slices[0]
             if isinstance(connection.srcport.slices[0], slice):
                 return connection.srcport.slices[0].start
+            raise ValueError(f'{type(connection.srcport.slices[0])} not '
+                             'supported on MTBuffer source port')
         return sorted(buff_links, key=sorting_key)
         
     def _sort_sinkport_mtbuff_links(self, buff_links)->List:
@@ -303,6 +305,8 @@ class MLIRBuilder:
                 return connection.sinkport.slices[0]
             if isinstance(connection.sinkport.slices[0], slice):
                 return connection.sinkport.slices[0].start
+            raise ValueError(f'{type(connection.sinkport.slices[0])} not '
+                             'supported on MTBuffer sink port')
         return sorted(buff_links, key=sorting_key)
 
     def _is_con_broadcast(self, connection)->bool:

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -143,21 +143,6 @@ class MtSplitConcat4AIEsNonAnonymousPlusN(AppBuilder):
         x_out[:] = self.mtbconcat(new_xs)
 
 
-class MtSplitConcat4AIEsNonAnonymous(AppBuilder):
-    def __init__(self, kernel):
-        super().__init__()
-        self.kernels = [kernel for _ in range(4)]
-        self.mtbsplit = MTSplit(4)
-        self.mtbconcat = MTConcat()
-
-    def callgraph(self, x_in, x_out):
-        new_xs = []
-        xs = self.mtbsplit(x_in)
-        for i in range(4):
-            new_xs.append(self.kernels[i](xs[i], xs[i].nbytes))
-        x_out[:] = self.mtbconcat(new_xs)
-
-
 class TwoInputsApp(AppBuilder):
     def callgraph(self, k, a, b, size):
         """Callgraph that tests a kernel with two input arguments """

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -127,6 +127,7 @@ class MtSplitConcat4AIEsPlusN(AppBuilder):
         x = MTConcat(xs)
         return x
 
+
 class MtSplitConcat4AIEsNonAnonymousPlusN(AppBuilder):
     def __init__(self):
         super().__init__()
@@ -149,7 +150,7 @@ class MtSplitConcat4AIEsNonAnonymous(AppBuilder):
         self.mtbsplit = MTSplit(4)
         self.mtbconcat = MTConcat()
 
-    def callgraph(self, x_in, x_out, n):
+    def callgraph(self, x_in, x_out):
         new_xs = []
         xs = self.mtbsplit(x_in)
         for i in range(4):

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -127,6 +127,35 @@ class MtSplitConcat4AIEsPlusN(AppBuilder):
         x = MTConcat(xs)
         return x
 
+class MtSplitConcat4AIEsNonAnonymousPlusN(AppBuilder):
+    def __init__(self):
+        super().__init__()
+        self.kernels = [PlusN() for _ in range(4)]
+        self.mtbsplit = MTSplit(4)
+        self.mtbconcat = MTConcat()
+
+    def callgraph(self, x_in, x_out, n):
+        new_xs = []
+        xs = self.mtbsplit(x_in)
+        for i in range(4):
+            new_xs.append(self.kernels[i](xs[i], xs[i].nbytes, n))
+        x_out[:] = self.mtbconcat(new_xs)
+
+
+class MtSplitConcat4AIEsNonAnonymous(AppBuilder):
+    def __init__(self, kernel):
+        super().__init__()
+        self.kernels = [kernel for _ in range(4)]
+        self.mtbsplit = MTSplit(4)
+        self.mtbconcat = MTConcat()
+
+    def callgraph(self, x_in, x_out, n):
+        new_xs = []
+        xs = self.mtbsplit(x_in)
+        for i in range(4):
+            new_xs.append(self.kernels[i](xs[i], xs[i].nbytes))
+        x_out[:] = self.mtbconcat(new_xs)
+
 
 class TwoInputsApp(AppBuilder):
     def callgraph(self, k, a, b, size):

--- a/tests/test_memtile_float.py
+++ b/tests/test_memtile_float.py
@@ -213,7 +213,9 @@ def test_memtile_average_mtsplit(datatype):
     trace_app.save(f'{imgdir}{trace_app.name}_{datatype_txt}.svg')
     app = AppRunner(f"{trace_app.name}.xclbin")
 
-    test_data = np.random.randint(-128, 127, size=array_in.shape, dtype=array_in.dtype)
+    np.random.seed(4102024)
+    test_data = np.random.randint(-128, 127, size=array_in.shape,
+                                  dtype=array_in.dtype)
     bo_in = app.allocate(shape=array_in.shape, dtype=array_in.dtype)
     bo_out = app.allocate(shape=array_out.shape, dtype=datatype)
 

--- a/tests/test_memtile_float.py
+++ b/tests/test_memtile_float.py
@@ -97,7 +97,7 @@ extern "C" {
 '''
 
 
-def average_behavior(invobj):
+def sum_behavior(invobj):
     # workaround to make sure there's enough data for the DMA
     invobj.out_buffer.array = np.zeros((16), dtype=invobj.in_buffer.array.dtype)
     invobj.out_buffer.array[0] = np.average(invobj.in_buffer.array)
@@ -111,7 +111,7 @@ def test_memtile_sum_mtsplit(datatype):
 
     class VectorSum():
         def __new__(cls, *args):
-            kobj = Kernel(vec_sum_src0, average_behavior)
+            kobj = Kernel(vec_sum_src0, sum_behavior)
             return kobj(*args) if len(args) > 0 else kobj
 
     class MtSplitConcat4AIEsSum(AppBuilder):

--- a/tests/test_memtile_float.py
+++ b/tests/test_memtile_float.py
@@ -150,7 +150,7 @@ def test_memtile_sum_mtsplit(datatype):
     del app
 
     for idx, val in enumerate(np.split(test_data, 4)):
-        assert np.isclose(np.sum(val), test_out[idx*16], rtol=0.2)
+        assert np.isclose(np.sum(val), test_out[idx*16], rtol=0.25)
 
 
 kernel_avrg_src = '''

--- a/tests/test_memtile_float.py
+++ b/tests/test_memtile_float.py
@@ -105,18 +105,12 @@ def test_memtile_sum_mtsplit(datatype):
 
     class VectorSum():
         def __new__(cls, *args):
-            kobj = Kernel(vec_sum_src0, sum_behavior)
-            return kobj(*args) if len(args) > 0 else kobj
-
-    class VectorSum():
-        def __new__(cls, *args):
             kobj = Kernel(vec_sum_src0, cls.behavioralfx)
             return kobj(*args) if len(args) > 0 else kobj
 
         def behavioralfx(self):
             self.out_buffer.array = np.zeros((16), dtype=datatype)
             self.out_buffer.array[0] = np.sum(self.in_buffer.array)
-
 
     class MtSplitConcat4AIEsSum(AppBuilder):
         def __init__(self):
@@ -219,7 +213,7 @@ def test_memtile_average_mtsplit(datatype):
     trace_app.save(f'{imgdir}{trace_app.name}_{datatype_txt}.svg')
     app = AppRunner(f"{trace_app.name}.xclbin")
 
-    test_data = np.random.randint(-128,127, size=array_in.shape, dtype=array_in.dtype)
+    test_data = np.random.randint(-128, 127, size=array_in.shape, dtype=array_in.dtype)
     bo_in = app.allocate(shape=array_in.shape, dtype=array_in.dtype)
     bo_out = app.allocate(shape=array_out.shape, dtype=datatype)
 

--- a/tests/test_memtile_float.py
+++ b/tests/test_memtile_float.py
@@ -18,7 +18,6 @@ def plus1_behavior(invobj):
     invobj.out_buffer.array = invobj.in_buffer.array
 
 
-
 @pytest.mark.parametrize('datatype', [np.float32, bfloat16])
 def test_memtile_distribute_join_4_non_anonymous(datatype):
 
@@ -77,7 +76,6 @@ def test_memtile_distribute_join_4_non_anonymous(datatype):
                        rtol=1e-02)
 
 
-
 vec_sum_src = '''
 #include <aie_api/aie.hpp>
 
@@ -110,6 +108,7 @@ def test_memtile_average_mtsplit(datatype):
 
     datatype_txt = 'float' if datatype == np.float32 else 'bfloat16'
     kernel_src0 = kernel_src.replace('bfloat16', datatype_txt)
+
     class VectorSum():
         def __new__(cls, *args):
             kobj = Kernel(kernel_src0, average_behavior)

--- a/tests/test_memtile_float.py
+++ b/tests/test_memtile_float.py
@@ -107,11 +107,11 @@ def average_behavior(invobj):
 def test_memtile_average_mtsplit(datatype):
 
     datatype_txt = 'float' if datatype == np.float32 else 'bfloat16'
-    kernel_src0 = kernel_src.replace('bfloat16', datatype_txt)
+    vec_sum_src0 = vec_sum_src.replace('bfloat16', datatype_txt)
 
     class VectorSum():
         def __new__(cls, *args):
-            kobj = Kernel(kernel_src0, average_behavior)
+            kobj = Kernel(vec_sum_src0, average_behavior)
             return kobj(*args) if len(args) > 0 else kobj
 
     class MtSplitConcat4AIEsSum(AppBuilder):

--- a/tests/test_memtile_float.py
+++ b/tests/test_memtile_float.py
@@ -104,7 +104,7 @@ def average_behavior(invobj):
 
 
 @pytest.mark.parametrize('datatype', [np.float32, bfloat16])
-def test_memtile_average_mtsplit(datatype):
+def test_memtile_sum_mtsplit(datatype):
 
     datatype_txt = 'float' if datatype == np.float32 else 'bfloat16'
     vec_sum_src0 = vec_sum_src.replace('bfloat16', datatype_txt)

--- a/tests/test_memtile_float.py
+++ b/tests/test_memtile_float.py
@@ -1,0 +1,77 @@
+import pytest
+import numpy as np
+from pathlib import Path
+from ml_dtypes import bfloat16
+
+from npu.build.appbuilder import AppBuilder
+from npu.build.mtkernel import MTConcat, MTSplit
+from npu.build.kernel import Kernel
+from npu.lib import Plus1
+from npu.runtime import AppRunner
+
+
+kernel_src = Plus1().srccode
+imgdir = str(Path(__file__).parent / "images") + '/'
+
+
+def plus1_behavior(invobj):
+    invobj.out_buffer.array = invobj.in_buffer.array
+
+
+
+@pytest.mark.parametrize('datatype', [np.float32, bfloat16])
+def test_memtile_distribute_join_4_non_anonymous(datatype):
+
+    datatype_txt = str(np.dtype(datatype))
+
+    if datatype == np.float32:
+        datatype_txt = 'float'
+    else:
+        datatype_txt = 'bfloat16'
+
+    kernel_src0 = kernel_src.replace('uint8_t', datatype_txt)
+
+    class Plus1Float():
+        def __new__(cls, *args):
+            kobj = Kernel(kernel_src0, plus1_behavior)
+            return kobj(*args) if len(args) > 0 else kobj
+
+    class MtSplitConcat4AIEsNonAnonymousFloat(AppBuilder):
+        def __init__(self):
+            super().__init__()
+            self.kernels = [Plus1Float() for _ in range(4)]
+            self.mtbsplit = MTSplit(4)
+            self.mtbconcat = MTConcat()
+
+        def callgraph(self, x_in, x_out):
+            new_xs = []
+            xs = self.mtbsplit(x_in)
+            for i in range(4):
+                new_xs.append(self.kernels[i](xs[i], xs[i].nbytes))
+            x_out[:] = self.mtbconcat(new_xs)
+
+    size = 512
+    array_in = np.zeros(shape=(4, size), dtype=datatype)
+    array_out = np.zeros(shape=(4, size), dtype=datatype)
+
+    trace_app = MtSplitConcat4AIEsNonAnonymousFloat()
+    trace_app.build(array_in, array_out)
+    trace_app.save(f'{imgdir}{trace_app.name}_{datatype_txt}.svg')
+    app = AppRunner(f"{trace_app.name}.xclbin")
+
+    test_data = np.random.randn(*array_in.shape).astype(datatype)
+    bo_in = app.allocate(shape=(4, size), dtype=datatype)
+    bo_out = app.allocate(shape=(4, size), dtype=datatype)
+
+    bo_in[:] = test_data
+    bo_in.sync_to_npu()
+
+    app.call(bo_in, bo_out)
+
+    bo_out.sync_from_npu()
+    test_out = np.array(bo_out).astype(np.float32)
+
+    del app
+
+    assert np.allclose((test_data + 1.).astype(np.float32), test_out,
+                       rtol=1e-02)

--- a/tests/test_memtile_float.py
+++ b/tests/test_memtile_float.py
@@ -97,12 +97,6 @@ extern "C" {
 '''
 
 
-def sum_behavior(invobj):
-    # workaround to make sure there's enough data for the DMA
-    invobj.out_buffer.array = np.zeros((16), dtype=invobj.in_buffer.array.dtype)
-    invobj.out_buffer.array[0] = np.average(invobj.in_buffer.array)
-
-
 @pytest.mark.parametrize('datatype', [np.float32, bfloat16])
 def test_memtile_sum_mtsplit(datatype):
 
@@ -113,6 +107,16 @@ def test_memtile_sum_mtsplit(datatype):
         def __new__(cls, *args):
             kobj = Kernel(vec_sum_src0, sum_behavior)
             return kobj(*args) if len(args) > 0 else kobj
+
+    class VectorSum():
+        def __new__(cls, *args):
+            kobj = Kernel(vec_sum_src0, cls.behavioralfx)
+            return kobj(*args) if len(args) > 0 else kobj
+
+        def behavioralfx(self):
+            self.out_buffer.array = np.zeros((16), dtype=datatype)
+            self.out_buffer.array[0] = np.sum(self.in_buffer.array)
+
 
     class MtSplitConcat4AIEsSum(AppBuilder):
         def __init__(self):
@@ -153,3 +157,81 @@ def test_memtile_sum_mtsplit(datatype):
 
     for idx, val in enumerate(np.split(test_data, 4)):
         assert np.isclose(np.sum(val), test_out[idx*16], rtol=0.2)
+
+
+kernel_avrg_src = '''
+#include <aie_api/aie.hpp>
+
+extern "C" {
+    void average(int8_t *in_buffer, bfloat16* out_buffer, uint32_t elements) {
+        ::aie::vector<int8_t, 32> buffer;
+        ::aie::accum<acc32, 32> acc;
+        acc.from_vector(::aie::zeros<int8_t, 32>());
+        uint16_t loop_count = (elements) >> 5;
+        for(int j=0; j<loop_count; j++) {
+            buffer = ::aie::load_v<32>(in_buffer);
+            acc = ::aie::add(acc, buffer);
+            in_buffer += 32;
+        }
+        auto sum = aie::reduce_add(acc.to_vector<int32_t>());
+        out_buffer[0] = bfloat16(float(sum)/float(elements));
+        out_buffer+=1;
+    }
+}
+'''
+
+
+@pytest.mark.parametrize('datatype', [np.float32, bfloat16])
+def test_memtile_average_mtsplit(datatype):
+
+    datatype_txt = 'float' if datatype == np.float32 else 'bfloat16'
+    kernel_avrg_src0 = kernel_avrg_src.replace('bfloat16', datatype_txt)
+
+    class Average():
+        def __new__(cls, *args):
+            kobj = Kernel(kernel_avrg_src0, cls.behavioralfx)
+            return kobj(*args) if len(args) > 0 else kobj
+
+        def behavioralfx(self):
+            self.out_buffer.array = np.zeros((16), dtype=datatype)
+            self.out_buffer.array[0] = np.average(self.in_buffer.array)
+
+    class MtSplitConcat4AIEsAverage(AppBuilder):
+        def __init__(self):
+            super().__init__()
+            self.kernels = [Average() for _ in range(4)]
+            self.mtbsplit = MTSplit(4)
+            self.mtbconcat = MTConcat()
+
+        def callgraph(self, x_in, x_out):
+            new_xs = []
+            xs = self.mtbsplit(x_in)
+            for i in range(4):
+                new_xs.append(self.kernels[i](xs[i], xs[i].shape[0]))
+            x_out[:] = self.mtbconcat(new_xs)
+
+    size = 512
+    array_in = np.zeros(shape=(size), dtype=np.int8)
+    array_out = np.zeros(shape=(64), dtype=datatype)
+
+    trace_app = MtSplitConcat4AIEsAverage()
+    trace_app.build(array_in, array_out)
+    trace_app.save(f'{imgdir}{trace_app.name}_{datatype_txt}.svg')
+    app = AppRunner(f"{trace_app.name}.xclbin")
+
+    test_data = np.random.randint(-128,127, size=array_in.shape, dtype=array_in.dtype)
+    bo_in = app.allocate(shape=array_in.shape, dtype=array_in.dtype)
+    bo_out = app.allocate(shape=array_out.shape, dtype=datatype)
+
+    bo_in[:] = test_data
+    bo_in.sync_to_npu()
+
+    app.call(bo_in, bo_out)
+
+    bo_out.sync_from_npu()
+    test_out = np.array(bo_out)
+
+    del app
+
+    for idx, val in enumerate(np.split(test_data, 4)):
+        assert np.isclose(np.average(val), test_out[idx*16], rtol=0.2)


### PR DESCRIPTION
<!-- Thanks for taking the time to submit a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->

### Describe the problem solved by the commit

Double tracing the app leads to error as discussed in #63 for non anonymous kernels.

### How is the problem solved?

- Caching the original tracing of the application.
- Added extensive testing with multiple MTSplit scenarios, different datatypes and sizes.
- Raise an error when the split type is not supported to avoid cryptic message such as `'<' not supported between instances of 'NoneType' and 'NoneType' `

### Are there any risks associated to the change?

No

### Is there a documentation impact?

No

### Checklist

<!-- We suggest you run all the pytests and report the output. Put an `x` in the boxes that apply -->

- [x] I added a test to cover my changes
- [x] Existing and new test pass
- [x] I read and I accept the [CONTRIBUTING.md](https://github.com/AMDResearch/Riallto/blob/main/CONTRIBUTING.md) guidelines

### Please provide screenshots (if applicable)

### Related issues

#63
