### PR TITLE
Check that kernel source code has extern C defined

### DIFF
--- a/npu/build/kernel.py
+++ b/npu/build/kernel.py
@@ -102,8 +102,8 @@ class Kernel(KernelMeta):
         """Verify that extern C is used"""
         tight_code = self.srccode.replace(' ', '').replace('	', '')
         if 'extern"C"' not in tight_code or '//extern"C"' in tight_code:
-            raise RuntimeError('extern "C" not found. Top level function '
-                               'should be wrapped by extern "C"')
+            raise SyntaxError('extern "C" not found. Top level function '
+                              'should be wrapped by extern "C"')
 
     def display(self)->None:
         """Render the kernel code in a jupyter notebook."""

--- a/npu/build/kernel.py
+++ b/npu/build/kernel.py
@@ -101,7 +101,7 @@ class Kernel(KernelMeta):
         """Verify that extern C is used"""
         tight_code = self.srccode.replace(' ', '').replace('	', '')
         if 'extern"C"' not in tight_code or '//extern"C"' not in tight_code:
-            raise SyntaxError('extern "C" not found. Top level function '
+            raise SyntaxError('extern "C" not found. Top level function ' \
                               'should be wrapped by extern "C"')
 
     def display(self)->None:

--- a/npu/build/kernel.py
+++ b/npu/build/kernel.py
@@ -102,7 +102,7 @@ class Kernel(KernelMeta):
         tight_code = self.srccode.replace(' ', '').replace('	', '')
         if 'extern"C"' not in tight_code or '//extern"C"' not in tight_code:
             raise SyntaxError('extern "C" not found. Top level function '
-                              'should be wrapped by extern "C" {...}')
+                              'should be wrapped by extern "C"')
 
     def display(self)->None:
         """Render the kernel code in a jupyter notebook."""

--- a/npu/build/kernel.py
+++ b/npu/build/kernel.py
@@ -12,6 +12,7 @@ from .buffers import Buffer
 from .port import BufferPort, RTPPort
 from typing import Optional, Callable, List, Dict
 import re
+import warnings
 
 
 class Kernel(KernelMeta):
@@ -100,9 +101,9 @@ class Kernel(KernelMeta):
     def _extern_c_check(self):
         """Verify that extern C is used"""
         tight_code = self.srccode.replace(' ', '').replace('	', '')
-        if 'extern"C"' not in tight_code or '//extern"C"' not in tight_code:
-            raise RuntimeError('extern "C" not found. Top level function '
-                               'should be wrapped by extern "C"')
+        if 'extern"C"' not in tight_code or '//extern"C"' in tight_code:
+            raise SyntaxError('extern "C" not found. Top level function '
+                              'should be wrapped by extern "C"')
 
     def display(self)->None:
         """Render the kernel code in a jupyter notebook."""

--- a/npu/build/kernel.py
+++ b/npu/build/kernel.py
@@ -102,8 +102,8 @@ class Kernel(KernelMeta):
         """Verify that extern C is used"""
         tight_code = self.srccode.replace(' ', '').replace('	', '')
         if 'extern"C"' not in tight_code or '//extern"C"' in tight_code:
-            raise SyntaxError('extern "C" not found. Top level function '
-                              'should be wrapped by extern "C"')
+            raise RuntimeError('extern "C" not found. Top level function '
+                               'should be wrapped by extern "C"')
 
     def display(self)->None:
         """Render the kernel code in a jupyter notebook."""

--- a/npu/build/kernel.py
+++ b/npu/build/kernel.py
@@ -101,8 +101,8 @@ class Kernel(KernelMeta):
         """Verify that extern C is used"""
         tight_code = self.srccode.replace(' ', '').replace('	', '')
         if 'extern"C"' not in tight_code or '//extern"C"' not in tight_code:
-            raise SyntaxError('extern "C" not found. Top level function ' \
-                              'should be wrapped by extern "C"')
+            raise RuntimeError('extern "C" not found. Top level function '
+                               'should be wrapped by extern "C"')
 
     def display(self)->None:
         """Render the kernel code in a jupyter notebook."""

--- a/npu/build/kernel.py
+++ b/npu/build/kernel.py
@@ -101,7 +101,7 @@ class Kernel(KernelMeta):
     def _extern_c_check(self):
         """Verify that extern C is used"""
         tight_code = self.srccode.replace(' ', '').replace('	', '')
-        if 'extern"C"' not in tight_code or '//extern"C"' in tight_code:
+        if 'extern"C"' not in tight_code:
             raise SyntaxError('extern "C" not found. Top level function '
                               'should be wrapped by extern "C"')
 

--- a/npu/build/kernel.py
+++ b/npu/build/kernel.py
@@ -56,6 +56,7 @@ class Kernel(KernelMeta):
 
         self.kb = KernelObjectBuilder(self.ktype, self.srccode, self.srcfile)
         self._main_function_sanity_check()
+        self._extern_c_check()
         self._expose_ports()
 
     def _expose_ports(self)->None:
@@ -95,6 +96,13 @@ class Kernel(KernelMeta):
     def _main_function_sanity_check(self)->None:
         if not self._main_function['rtnType'] == "void":
             raise RuntimeError(f"The return type of the top_level function should be void not {self._main_function['rtnType']}")
+
+    def _extern_c_check(self):
+        """Verify that extern C is used"""
+        tight_code = self.srccode.replace(' ', '').replace('	', '')
+        if 'extern"C"' not in tight_code or '//extern"C"' not in tight_code:
+            raise SyntaxError('extern "C" not found. Top level function '
+                              'should be wrapped by extern "C" {...}')
 
     def display(self)->None:
         """Render the kernel code in a jupyter notebook."""

--- a/tests/test_externc.py
+++ b/tests/test_externc.py
@@ -9,8 +9,6 @@ from npu.lib import Plus1
 kernel_src = Plus1().srccode
 
 kernel_src1 = kernel_src.replace('\n\n}', '')
-kernel_src2 = kernel_src1.replace('extern "C" {', '')
-kernel_src1 = kernel_src1.replace('extern "C"', '// extern "C"')
 
 
 def test_externc_good():
@@ -19,8 +17,9 @@ def test_externc_good():
     assert krnl_obj
 
 
-@pytest.mark.parametrize('src_code', [kernel_src1, kernel_src2])
-def test_externc_bad(src_code):
+@pytest.mark.parametrize('replacewith', ['', '// extern "C"'])
+def test_externc_bad(replacewith):
+    src_code = kernel_src1.replace('extern "C" {', replacewith)
 
     with pytest.raises(SyntaxError) as excinfo:
         _ = Kernel(src_code)

--- a/tests/test_externc.py
+++ b/tests/test_externc.py
@@ -1,0 +1,28 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import pytest
+from npu.build.kernel import Kernel
+from npu.lib import Plus1
+
+
+kernel_src = Plus1().srccode
+
+kernel_src1 = kernel_src.replace('\n\n}', '')
+kernel_src2 = kernel_src1.replace('extern "C" {', '')
+kernel_src1 = kernel_src1.replace('extern "C"', '// extern "C"')
+
+
+def test_externc_good():
+    krnl_obj = Kernel(kernel_src)
+    krnl_obj.build()
+    assert krnl_obj
+
+
+@pytest.mark.parametrize('src_code', [kernel_src1, kernel_src2])
+def test_externc_bad(src_code):
+    krnl_obj = Kernel(src_code)
+    with pytest.raises(SyntaxError) as excinfo:
+        krnl_obj.build()
+
+    assert 'extern "C" not found.' in str(excinfo.value)

--- a/tests/test_externc.py
+++ b/tests/test_externc.py
@@ -17,7 +17,7 @@ def test_externc_good():
     assert krnl_obj
 
 
-@pytest.mark.parametrize('replacewith', ['', '// extern "C"'])
+@pytest.mark.parametrize('replacewith', [''])
 def test_externc_bad(replacewith):
     src_code = kernel_src1.replace('extern "C" {', replacewith)
 

--- a/tests/test_externc.py
+++ b/tests/test_externc.py
@@ -21,8 +21,8 @@ def test_externc_good():
 
 @pytest.mark.parametrize('src_code', [kernel_src1, kernel_src2])
 def test_externc_bad(src_code):
-    krnl_obj = Kernel(src_code)
+
     with pytest.raises(RuntimeError) as excinfo:
-        krnl_obj.build()
+        _ = Kernel(src_code)
 
     assert 'extern "C" not found.' in str(excinfo.value)

--- a/tests/test_externc.py
+++ b/tests/test_externc.py
@@ -22,7 +22,7 @@ def test_externc_good():
 @pytest.mark.parametrize('src_code', [kernel_src1, kernel_src2])
 def test_externc_bad(src_code):
     krnl_obj = Kernel(src_code)
-    with pytest.raises(SyntaxError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         krnl_obj.build()
 
     assert 'extern "C" not found.' in str(excinfo.value)

--- a/tests/test_externc.py
+++ b/tests/test_externc.py
@@ -22,7 +22,7 @@ def test_externc_good():
 @pytest.mark.parametrize('src_code', [kernel_src1, kernel_src2])
 def test_externc_bad(src_code):
 
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(SyntaxError) as excinfo:
         _ = Kernel(src_code)
 
     assert 'extern "C" not found.' in str(excinfo.value)

--- a/tests/test_externc.py
+++ b/tests/test_externc.py
@@ -22,7 +22,7 @@ def test_externc_good():
 @pytest.mark.parametrize('src_code', [kernel_src1, kernel_src2])
 def test_externc_bad(src_code):
     krnl_obj = Kernel(src_code)
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(SyntaxError) as excinfo:
         krnl_obj.build()
 
     assert 'extern "C" not found.' in str(excinfo.value)


### PR DESCRIPTION
<!-- Thanks for taking the time to submit a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->

### Describe the problem solved by the commit

No check is done about kernel wrapping top function in extern C, this leads to application not being built with a not very useful error message. #65 

### How is the problem solved?

Add two simple checks to see if the extern C string is in the source file

### Are there any risks associated to the change?

No

### Is there a documentation impact?

No

### Checklist

<!-- We suggest you run all the pytests and report the output. Put an `x` in the boxes that apply -->

- [x] I added a test to cover my changes
- [x] Existing and new test pass
- [x] I read and I accept the [CONTRIBUTING.md](https://github.com/AMDResearch/Riallto/blob/main/CONTRIBUTING.md) guidelines

### Please provide screenshots (if applicable)

### Related issues
